### PR TITLE
Cashback and playwall integration

### DIFF
--- a/apps/api/src/app/controllers/pools/quests/list.controller.ts
+++ b/apps/api/src/app/controllers/pools/quests/list.controller.ts
@@ -9,6 +9,7 @@ import {
     QuestDaily,
     QuestWebhook,
 } from '@thxnetwork/api/models';
+import { QuestCashback } from '@thxnetwork/api/models/QuestCashback';
 
 const validation = [
     param('id').isMongoId(),
@@ -34,10 +35,11 @@ const controller = async (req: Request, res: Response) => {
         { $unionWith: { coll: QuestWeb3.collection.name } },
         { $unionWith: { coll: QuestGitcoin.collection.name } },
         { $unionWith: { coll: QuestWebhook.collection.name } },
+        { $unionWith: { coll: QuestCashback.collection.name } },
         { $match },
     ];
     const arr = await Promise.all(
-        [QuestDaily, QuestInvite, QuestSocial, QuestCustom, QuestWeb3, QuestGitcoin, QuestWebhook].map(
+        [QuestDaily, QuestInvite, QuestSocial, QuestCustom, QuestWeb3, QuestGitcoin, QuestWebhook, QuestCashback].map(
             async (model) => await model.countDocuments($match),
         ),
     );

--- a/apps/api/src/app/controllers/quests/cashback/cashback.router.ts
+++ b/apps/api/src/app/controllers/quests/cashback/cashback.router.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as CreateEntry from './entries/post.controller';
+import { assertRequestInput, guard } from '@thxnetwork/api/middlewares';
+
+const router: express.Router = express.Router({ mergeParams: true });
+
+router.post('/:id/entries', guard.check(['pools:write']), assertRequestInput(CreateEntry.validation), CreateEntry.controller);
+
+export default router;

--- a/apps/api/src/app/controllers/quests/cashback/entries/post.controller.ts
+++ b/apps/api/src/app/controllers/quests/cashback/entries/post.controller.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from 'express';
+import { Identity, Pool, QuestCustom } from '@thxnetwork/api/models';
+import { body, param } from 'express-validator';
+import { JobType, QuestVariant } from '@thxnetwork/common/enums';
+import { agenda } from '@thxnetwork/api/util/agenda';
+import QuestService from '@thxnetwork/api/services/QuestService';
+import { NotFoundError } from '@thxnetwork/api/util/errors';
+import { QuestCashback } from '@thxnetwork/api/models/QuestCashback';
+import { logger } from '@thxnetwork/api/util/logger';
+import AccountProxy from '@thxnetwork/api/proxies/AccountProxy';
+
+const validation = [
+    param('id').isMongoId(),
+    body('amount').isNumeric(),
+    body('identityUuid').isUUID(),
+    body('santaQuestType')
+        .isString()
+        .custom((value) => {
+            if (value !== 'cashback' && value !== 'offerwall') {
+                throw new Error('Invalid santaQuestType. It must be either "cashback" or "offerwall".');
+            }
+            return true;
+        }),
+    body('santaQuestId').isString(),
+];
+
+const controller = async ({ params, body }: Request, res: Response) => {
+    const { identityUuid, amount, santaQuestType, santaQuestId } = body;
+
+    const quest = await QuestCashback.findById(params.id);
+    if (!quest) throw new NotFoundError('Quest not found.');
+
+    const pool = await Pool.findById(quest.poolId);
+    if (!pool) throw new NotFoundError('Could not find pool for client');
+
+    const identity = await Identity.findOne({ uuid: identityUuid });
+    if (!identity) throw new NotFoundError('Could not find ID for uuid');
+    
+    const data = {
+        amount,
+        santaQuestType,
+        santaQuestId
+    }
+    
+    const account = await AccountProxy.findById(identity.sub);
+
+    const { result, reason } = await QuestService.getValidationResult(quest.variant, {
+        quest,
+        account,
+        data,
+    });
+    if (!result) return res.json({ error: reason });
+
+    const job = await agenda.now(JobType.CreateQuestEntry, {
+        variant: QuestVariant.CashbackPlaywall,
+        questId: String(quest._id),
+        sub: identity.sub,
+        data: { ...data, isClaimed: true },
+    });
+
+    res.json({ jobId: job.attrs._id });
+};
+
+export { controller, validation };

--- a/apps/api/src/app/controllers/quests/quests.router.ts
+++ b/apps/api/src/app/controllers/quests/quests.router.ts
@@ -9,6 +9,7 @@ import RouterQuestGitcoin from './gitcoin/gitcoin.router';
 import RouterQuestDaily from './daily/daily.router';
 import RouterQuestCustom from './custom/custom.router';
 import RouterQuestWebhook from './webhook/webhook.router';
+import RouterQuestCashback from './cashback/cashback.router';
 
 const router: express.Router = express.Router();
 
@@ -22,5 +23,6 @@ router.use('/gitcoin', RouterQuestGitcoin);
 router.use('/daily', RouterQuestDaily);
 router.use('/custom', RouterQuestCustom);
 router.use('/webhook', RouterQuestWebhook);
+router.use('/cashback', RouterQuestCashback);
 
 export default router;

--- a/apps/api/src/app/models/QuestCashback.ts
+++ b/apps/api/src/app/models/QuestCashback.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+import { questSchema } from '@thxnetwork/api/models/Quest';
+
+export type QuestCashbackDocument = mongoose.Document & TQuestCashback;
+
+export const QuestCashback = mongoose.model<QuestCashbackDocument>(
+    'QuestCashback',
+    new mongoose.Schema(
+        {
+            ...(questSchema as any),
+            limit: Number,
+        },
+        { timestamps: true },
+    ),
+    'questcashback',
+);

--- a/apps/api/src/app/models/QuestCashbackEntry.ts
+++ b/apps/api/src/app/models/QuestCashbackEntry.ts
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose';
+
+export type QuestCashbackEntryDocument = mongoose.Document & TQuestCashbackEntry;
+
+export const QuestCashbackEntry = mongoose.model<QuestCashbackEntryDocument>(
+    'QuestCashbackEntry',
+    new mongoose.Schema(
+        {
+            questId: String,
+            sub: String,
+            uuid: String,
+            amount: Number,
+            isClaimed: Boolean,
+            poolId: String,
+            santaQuestType: String,
+            santaQuestId: String,
+        },
+        { timestamps: true },
+    ),
+    'questcashbackentry',
+);

--- a/apps/api/src/app/services/QuestCashbackService.ts
+++ b/apps/api/src/app/services/QuestCashbackService.ts
@@ -1,0 +1,116 @@
+import {
+    Identity,
+    IdentityDocument,
+    WalletDocument,
+} from '@thxnetwork/api/models';
+import { IQuestService } from './interfaces/IQuestService';
+import { QuestCashback, QuestCashbackDocument } from '../models/QuestCashback';
+import { QuestCashbackEntry } from '../models/QuestCashbackEntry';
+import { logger } from '../util/logger';
+
+export default class QuestCashbackService implements IQuestService {
+    models = {
+        quest: QuestCashback,
+        entry: QuestCashbackEntry,
+    };
+
+    async findEntryMetadata({ quest }: { quest: QuestCashbackDocument }) {
+        const uniqueParticipantIds = await QuestCashbackEntry.countDocuments({
+            questId: String(quest._id),
+        }).distinct('sub');
+
+        return { participantCount: uniqueParticipantIds.length };
+    }
+
+    async isAvailable({
+        quest,
+        account,
+        data
+    }: {
+        quest: QuestCashbackDocument;
+        wallet?: WalletDocument;
+        account?: TAccount;
+        data: Partial<TQuestCashbackEntry>;
+    }): Promise<TValidationResult> {
+        
+        let entries = await this.models.entry.find({
+            questId: quest._id,
+            sub: account.sub,
+            isClaimed: true,
+            santaQuestId: data.santaQuestId,
+            santaQuestType: data.santaQuestType
+        });
+
+        if (entries.length > 0) {
+            return { result: false, reason: 'Entry already exists.' };
+        }
+
+        return { result: true, reason: '' };
+    }
+
+    async getAmount({ quest, data }: { quest: QuestCashbackDocument; wallet: WalletDocument; account: TAccount; data: any }) {
+        return data.amount;
+    }
+
+    async decorate({
+        quest,
+        account,
+        data,
+    }: {
+        quest: QuestCashbackDocument;
+        account?: TAccount;
+        data: Partial<TQuestCustomEntry>;
+    }) {
+        const entries = await this.findAllEntries({ quest, account });
+        const isAvailable = await this.isAvailable({ quest, account, data });
+        const pointsAvailable = 0;
+
+        return {
+            ...quest,
+            eventName: '', // FK Deprecrates March 15th 2024
+            isAvailable: isAvailable.result,
+            pointsAvailable,
+            entries
+        };
+    }
+
+    async getValidationResult({
+        quest,
+        account,
+    }: {
+        quest: QuestCashbackDocument;
+        account: TAccount;
+        data: Partial<TQuestCustomEntry>;
+    }): Promise<{ reason: string; result: boolean }> {
+        // See if there are identities
+        const identities = await this.findIdentities({ quest, account });
+        if (!identities.length) {
+            return {
+                result: false,
+                reason: 'No identity connected to this account. Please ask for this in your community!',
+            };
+        }
+
+        // Find existing entries for this quest and check optional limit
+        const entries = await this.findAllEntries({ quest, account });
+        if (quest.limit && entries.length >= quest.limit) {
+            return { result: false, reason: 'Quest entry limit has been reached' };
+        }
+
+        return { result: true, reason: '' };
+    }
+
+    private async findAllEntries({ quest, account}: { quest: QuestCashbackDocument; account: TAccount }) {
+        if (!account) return [];
+        return await this.models.entry.find({
+            questId: quest._id,
+            sub: account.sub,
+            isClaimed: true,
+        });
+    }
+
+    private async findIdentities({ quest, account }: { quest: QuestCashbackDocument; account: TAccount }) {
+        if (!account || !account.sub) return [];
+        return await Identity.find({ poolId: quest.poolId, sub: account.sub });
+    }
+}

--- a/apps/api/src/app/services/QuestService.ts
+++ b/apps/api/src/app/services/QuestService.ts
@@ -116,7 +116,7 @@ export default class QuestService {
         return Quest.findByIdAndUpdate(questId, options, { new: true });
     }
 
-    static getAmount(variant: QuestVariant, quest: TQuest, account: TAccount, data?: { metadata: any }) {
+    static getAmount(variant: QuestVariant, quest: TQuest, account: TAccount, data?: any) {
         return serviceMap[variant].getAmount({ quest, account, data });
     }
 
@@ -214,6 +214,8 @@ export default class QuestService {
                 sub: account.sub,
                 questId: quest.id,
                 poolId: pool.id,
+                santaQuestType: data.santaQuestType,
+                santaQuestId: data.santaQuestId,
                 uuid: v4(),
             } as TQuestEntry);
             if (!entry) throw new Error('Entry creation failed.');

--- a/apps/api/src/app/services/interfaces/IQuestService.ts
+++ b/apps/api/src/app/services/interfaces/IQuestService.ts
@@ -10,6 +10,7 @@ import QuestWeb3Service from '../QuestWeb3Service';
 import QuestWebhookService from '../QuestWebhookService';
 import { QuestVariant } from '@thxnetwork/common/enums';
 import { PoolDocument } from '@thxnetwork/api/models';
+import QuestCashbackService from '../QuestCashbackService';
 
 export interface IInviteService extends IQuestService {
     assertQuestEntry(options: { pool: PoolDocument; quest: TQuest; account: TAccount }): Promise<void>;
@@ -44,4 +45,5 @@ export const serviceMap: {
     [QuestVariant.Web3]: new QuestWeb3Service(),
     [QuestVariant.Gitcoin]: new QuestGitcoinService(),
     [QuestVariant.Webhook]: new QuestWebhookService(),
+    [QuestVariant.CashbackPlaywall]: new QuestCashbackService()
 };

--- a/libs/common/src/lib/enums/RewardVariant.ts
+++ b/libs/common/src/lib/enums/RewardVariant.ts
@@ -17,4 +17,5 @@ export enum QuestVariant {
     Web3 = 6,
     Gitcoin = 7,
     Webhook = 8,
+    CashbackPlaywall = 100,
 }

--- a/libs/common/src/lib/types/Quest.d.ts
+++ b/libs/common/src/lib/types/Quest.d.ts
@@ -1,4 +1,4 @@
-type TQuest = TQuestDaily | TQuestInvite | TQuestSocial | TQuestCustom | TQuestWeb3 | TQuestGitcoin | TQuestWebhook;
+type TQuest = TQuestDaily | TQuestInvite | TQuestSocial | TQuestCustom | TQuestWeb3 | TQuestGitcoin | TQuestWebhook | TQuestCashback;
 type TQuestEntry =
     | TQuestDailyClaim
     | TQuestInviteEntry
@@ -6,7 +6,8 @@ type TQuestEntry =
     | TQuestCustomEntry
     | TQuestWeb3Entry
     | TQuestGitcoinEntry
-    | TQuestWebhookEntry;
+    | TQuestWebhookEntry
+    | TQuestCashbackEntry;
 
 type TQuestEntryMetadata = TQuestSocialEntryMetadata | TQuestWeb3EntryMetadata;
 

--- a/libs/common/src/lib/types/QuestCashback.d.ts
+++ b/libs/common/src/lib/types/QuestCashback.d.ts
@@ -1,0 +1,3 @@
+type TQuestCashback = TBaseQuest & {
+    limit: number;
+};

--- a/libs/common/src/lib/types/QuestCashbackEntry.d.ts
+++ b/libs/common/src/lib/types/QuestCashbackEntry.d.ts
@@ -1,0 +1,11 @@
+type TQuestCashbackEntry = {
+    questId: string;
+    sub: string;
+    uuid: string;
+    amount: number;
+    santaQuestType: string;
+    santaQuestId: string;
+    isClaimed: boolean;
+    poolId: string;
+    createdAt: Date;
+};


### PR DESCRIPTION
Introduced new quest type called Cashback to store entry data for santa cashback and playwall

POST - https://localhost:3000/v1/quests/cashback/{questId}/entries

Body

{
    "amount": "1000",
    "identityUuid": "44aa1b6e-88b5-70cf-dac2-ac17213c57c8",
    "santaQuestId": "test12344",
    "santaQuestType": "offerwall" // can be offerwall or cashback
} 

We need to create identity with clid 